### PR TITLE
Add condition to use primary breadcrumb if available

### DIFF
--- a/templates/app/views/layouts/storefront.html.erb
+++ b/templates/app/views/layouts/storefront.html.erb
@@ -30,7 +30,7 @@
       <%= render 'layouts/header', taxons: @taxons, taxon: @taxon %>
       <main>
         <%= render BreadcrumbsComponent.new(
-          taxon: @taxon,
+          taxon: @product&.primary_taxon || @taxon,
           item_classes: 'text-body-xs text-gray-500',
           separator_classes: 'text-body-xs text-gray-500 ml-2',
           container_classes: 'flex gap-2',


### PR DESCRIPTION
### Feature Description
 
#### Storefront Breadcrumb Rendering Update
 
This feature introduces a modification to the storefront layout, improving the breadcrumb rendering logic. It ensures that the breadcrumb navigation dynamically adapts based on the page being viewed.
 
- **Dynamic Breadcrumb Logic**: The breadcrumb trail now checks for the product’s `primary_breadcrumb_taxon` if a specific `@taxon` is not set. This allows the breadcrumb to be more context-sensitive and relevant when viewing product pages.
- **Improved Product Page Experience**: If no taxon is provided for a product page, the breadcrumb will use the product's `primary_breadcrumb_taxon` to create a more accurate and meaningful navigation trail.
- **Fallback Mechanism**: The breadcrumb system automatically falls back to the `primary_breadcrumb_taxon` in product pages, ensuring continuity in navigation across all product views.
 
This update ensures that users have a clear, contextually relevant breadcrumb path while browsing products, improving both usability and the overall user experience on the storefront.


