### PR TITLE
Add email, vat_id and reverse_charge_status on address page

### DIFF
--- a/templates/app/views/address/_form_hidden.html.erb
+++ b/templates/app/views/address/_form_hidden.html.erb
@@ -9,3 +9,5 @@
 <%= form.hidden_field :zipcode %>
 <%= form.hidden_field :phone %>
 <%= form.hidden_field :alternative_phone %>
+<%= form.hidden_field :email %>
+<%= form.hidden_field :vat_id %>

--- a/templates/app/views/checkouts/steps/address_step/_address_inputs.html.erb
+++ b/templates/app/views/checkouts/steps/address_step/_address_inputs.html.erb
@@ -111,4 +111,14 @@
       <%= form.telephone_field :alternative_phone, autocomplete: "#{address_type} tel" %>
     </div>
   <% end %>
+
+  <div class="text-input">
+    <%= form.label :email, "#{I18n.t("spree.email")}:" %>
+    <%= form.email_field :email, autocomplete: "#{address_type} email"%>
+  </div>
+
+  <div class="text-input">
+    <%= form.label :vat_id, "#{I18n.t("spree.vat_id")}:" %>
+    <%= form.text_field :vat_id, autocomplete: "#{address_type} email" %>
+  </div>
 </div>


### PR DESCRIPTION
Updated the address page to have  email, vat_id and reverse_charge_status

Dependent PR for: https://github.com/gms-electronics/solidus/pull/12